### PR TITLE
Reimplement StructMap & StructDispatchMap using variant-spec (fixes issue #5)

### DIFF
--- a/src/schema_refined/core.clj
+++ b/src/schema_refined/core.clj
@@ -1,7 +1,6 @@
 (ns schema-refined.core
   (:require [schema.core :as s]
             [schema.spec.core :as schema-spec]
-            [schema.spec.leaf :as schema-leaf]
             [schema.spec.variant :as schema-variant]
             [schema.utils :as schema-utils]
             [clojure.string :as cstr])


### PR DESCRIPTION
Fixes issue #5.

There are two obvious issues with new `StructDispatchMap` implementation and I'm not sure this simplification is actually worth it :disappointed: :

1) we can't obtain dispatch value to show in error in case no dispatch branches matched the value https://github.com/KitApps/schema-refined/compare/feature-cleanup-struct-impl?expand=1#diff-599ae3465d726ee432cd5735a58c70a9R1245 I believe this can really harm readability.

2) dispatch value for input would  be extracted for each dispatch branch separately until one of them matches https://github.com/KitApps/schema-refined/compare/feature-cleanup-struct-impl?expand=1#diff-599ae3465d726ee432cd5735a58c70a9R1240 This one probably harms performance a bit, especially if dispatch-fn is complex (but why would one make it complex?), but in my opinion is not as bad as the first issue I mentioned.