### PR TITLE
Switch CI to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+
+shared: &shared
+  environment:
+    LEIN_ROOT: "true"
+  steps:
+    - checkout
+    - restore_cache:
+        key: << checksum "project.clj" >>
+    - run: lein with-profiles dev:dev,1.8:dev,1.9:dev,1.10 deps
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: << checksum "project.clj" >>
+    - run: lein do clean, with-profiles dev:dev,1.8:dev,1.9:dev,1.10 test
+
+jobs:
+  jdk-8:
+    docker:
+      - image: circleci/clojure:openjdk-8-lein-2.9.0
+    <<: *shared
+
+  jdk-11:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.0
+    <<: *shared
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "jdk-8"
+      - "jdk-11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: clojure
-lein: lein
-script: lein do clean, with-profiles dev:dev,1.8:dev,1.9:dev,1.10 test
-jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - openjdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## schema-refined
 
+[![CircleCI](https://circleci.com/gh/KitApps/schema-refined.svg?style=svg)](https://circleci.com/gh/KitApps/schema-refined)
+
 Powerful "refined" steroids for [schema](https://github.com/plumatic/schema) library.
 
 Type refinement is all about making the types (schemas) more precise to keep you away from errors and bugs. All heavy lifting of checking/validation the shape of the data is done by `schema` library. Here we introduce a few new concepts to make schemas flexible and more expressive:


### PR DESCRIPTION
Feature of Travis CI is [not clear](https://www.reddit.com/r/devops/comments/at3oyq/it_looks_like_ibera_is_gutting_travis_ci_just_a/), so let's switch to Circle CI. 

Unfortunately Circle CI doesn't provide Oracle JDK Docker images, so I didn't configure them yet, but it could be done using the third party ones if needed.

Build page https://circleci.com/gh/KitApps/schema-refined (please ignore the failed builds, I've tested latest version of the config file in the personal fork).